### PR TITLE
Add endpoint to get categories from bdd

### DIFF
--- a/src/api-gateway/api/auth/clients/postgresql.py
+++ b/src/api-gateway/api/auth/clients/postgresql.py
@@ -193,4 +193,20 @@ class PostgreSQLClient:
         response.raise_for_status()
 
         return response.json()
+    
+    def read_categories(self, token: str, table: str) -> Dict[str, Any]:
+        """ Liste les catégories en base. """
+        base_url = self.settings.API_POSTGRESQL_BASE_URL
+        headers = self.get_headers(token)
+        session = self.get_session()
+
+        endpoint = f"{base_url}/api/internal/postgresql/entity/{table}"
+        logger.debug(f"Request URL: {endpoint}")
+
+        response = session.get(endpoint, headers=headers)
+        logger.debug(f"Response Status Code: {response.status_code}")
+        logger.debug(f"Response Content: {response.text}")
+        response.raise_for_status()
+
+        return response.json()
 

--- a/src/api-gateway/api/routes/category/get.py
+++ b/src/api-gateway/api/routes/category/get.py
@@ -6,10 +6,7 @@ from config.settings import Settings
 from api.auth.clients.manager import ClientManager, create_client_manager
 from api.auth.token.manager import TokenManager, create_token_manager
 
-
-# Configurer le logger pour ce module
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)  # Configurez le niveau de logging approprié
+logger = logging.getLogger("gateway")
 
 router = APIRouter()
 
@@ -44,8 +41,6 @@ def read_psql_entity(table: str, client, token) -> dict:
         if not data:
             raise HTTPException(status_code=404, detail=f"{table}")
         return data
-    except HTTPException:
-        raise
     except Exception as e:
         logger.error(f"Error read '{table}': {e}")
         raise HTTPException(status_code=500, detail=f"Error read '{table}': {e}")
@@ -56,7 +51,7 @@ async def read_ad(
     user_data: dict = Depends(get_user_data_from_token),
     client_manager: ClientManager = Depends(get_client_manager),
 ):
-    logger.info("Starting get categories...")
+    logger.debug("Getting categories...")
     
     postgresql_token = user_data.get('tokens', {}).get('postgresql') 
     if not postgresql_token:
@@ -66,7 +61,7 @@ async def read_ad(
 
     ### Retrieves categories ###
     data = read_psql_entity("categories", postgresql_client, postgresql_token)
-    payload = data.get("categories", data) if isinstance(data, dict) else data
+    payload = data.get("categories", data)
 
     categories = [Category.model_validate(item) for item in payload]
     return categories

--- a/src/api-gateway/api/routes/category/get.py
+++ b/src/api-gateway/api/routes/category/get.py
@@ -1,0 +1,72 @@
+import logging
+from fastapi import APIRouter, Depends, HTTPException, Request, Header
+from pydantic import BaseModel
+from typing import List, Dict
+from config.settings import Settings
+from api.auth.clients.manager import ClientManager, create_client_manager
+from api.auth.token.manager import TokenManager, create_token_manager
+
+
+# Configurer le logger pour ce module
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)  # Configurez le niveau de logging approprié
+
+router = APIRouter()
+
+class Category(BaseModel):
+    code: int
+    label: str
+
+def get_settings(request: Request) -> Settings:
+    return request.app.state.settings
+
+def get_token_manager(request: Request) -> TokenManager:
+    settings = get_settings(request)
+    return create_token_manager(settings)
+
+def get_client_manager(request: Request) -> ClientManager:
+    settings = get_settings(request)
+    return create_client_manager(settings)
+
+def get_user_data_from_token(
+    token_manager: TokenManager = Depends(get_token_manager),
+    authorization: str = Header(...)
+) -> Dict:
+    """Récupère les données utilisateur à partir du token JWT."""
+    logger.info("Extracting user data from token...")
+    return token_manager.get_user_data_from_token(authorization)
+
+def read_psql_entity(table: str, client, token) -> dict:
+    try:
+        logger.debug(f"Read '{table}'")
+        response = client.read_categories(token=token, table=table)
+        data = response
+        if not data:
+            raise HTTPException(status_code=404, detail=f"{table}")
+        return data
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error read '{table}': {e}")
+        raise HTTPException(status_code=500, detail=f"Error read '{table}': {e}")
+
+
+@router.get("/get_categories", response_model=List[Category])
+async def read_ad(
+    user_data: dict = Depends(get_user_data_from_token),
+    client_manager: ClientManager = Depends(get_client_manager),
+):
+    logger.info("Starting get categories...")
+    
+    postgresql_token = user_data.get('tokens', {}).get('postgresql') 
+    if not postgresql_token:
+        raise HTTPException(status_code=401, detail="Missing PostgreSQL token")
+    
+    postgresql_client = client_manager.get_client("postgresql")
+
+    ### Retrieves categories ###
+    data = read_psql_entity("categories", postgresql_client, postgresql_token)
+    payload = data.get("categories", data) if isinstance(data, dict) else data
+
+    categories = [Category.model_validate(item) for item in payload]
+    return categories

--- a/src/api-gateway/main.py
+++ b/src/api-gateway/main.py
@@ -9,6 +9,7 @@ from api.routes.ad.create import router as create_router
 from api.routes.ad.delete import router as ad_delete_router
 from api.routes.ad.read import router as read_router
 from api.routes.ad.update import router as update_router
+from api.routes.category.get import router as categories_router
 from config.settings import Settings
 import logging
 
@@ -44,6 +45,7 @@ def create_app(settings: Settings):
     app.include_router(ad_delete_router, prefix=settings.PROTECTED_ENDPOINT_URL, tags=["ad_delete_router"])
     app.include_router(read_router, prefix=settings.PROTECTED_ENDPOINT_URL, tags=["ad_read"])
     app.include_router(update_router, prefix=settings.PROTECTED_ENDPOINT_URL, tags=["ad_update"])
+    app.include_router(categories_router, prefix=settings.PROTECTED_ENDPOINT_URL, tags=["categories"])
 
     # Route racine
     @app.get("/")

--- a/src/api-gateway/main.py
+++ b/src/api-gateway/main.py
@@ -15,7 +15,7 @@ import logging
 
 # Configurer le logging
 logging.basicConfig(level=logging.WARNING)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("gateway")
 
 def create_app(settings: Settings):
     app = FastAPI()

--- a/src/api-gateway/test/entity/test_get_categories.py
+++ b/src/api-gateway/test/entity/test_get_categories.py
@@ -1,0 +1,57 @@
+import sys
+import os
+import random
+from fastapi.testclient import TestClient
+from main import app
+
+# Configuration propre du PYTHONPATH (une seule fois, au début du fichier)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from test.config.config import config
+from test.config.test_settings import test_settings
+
+client = TestClient(app)
+
+# Générer un entier aléatoire entre config.RANDOM_RANGE_START et config.RANDOM_RANGE_END
+RND = random.randint(config.RANDOM_RANGE_START, config.RANDOM_RANGE_END)
+USERNAME = f"{RND}-flow-user"
+EMAIL = f"{USERNAME}@{config.DEFAULT_DOMAIN}"
+PASSWORD = USERNAME
+
+DEMO_IMAGE_PATH = os.path.join("test", "entity", "demo_image.jpg")
+
+
+def _signup_and_login():
+    # Signup
+    r = client.post(
+        f"{test_settings.PROTECTED_ENDPOINT_URL}/signup",
+        json={"username": USERNAME, "email": EMAIL, "password": PASSWORD},
+    )
+    assert r.status_code == 200, f"Signup a échoué: {r.status_code} {r.text}"
+
+    # Login
+    r = client.post(
+        f"{test_settings.PROTECTED_ENDPOINT_URL}/login",
+        data={"username": USERNAME, "password": PASSWORD},
+    )
+    assert r.status_code == 200, f"Login a échoué: {r.status_code} {r.text}"
+
+    token = r.json()["access_token"]
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
+        "X-API-Key": token,
+    }
+    return headers
+
+def test_get_categories():
+
+    headers = _signup_and_login()
+
+    # READ
+    response = client.get(f"{test_settings.PROTECTED_ENDPOINT_URL}/get_categories", headers=headers)
+    assert response.status_code == 200, f"Get failed : {response.status_code} {response.text}"
+    categories_data = response.json()
+    assert response.status_code == 200
+    assert len(categories_data) >= 2
+

--- a/src/api-postgresql/api/postgresql/entity/categories.py
+++ b/src/api-postgresql/api/postgresql/entity/categories.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from pydantic import BaseModel
+from config.db import get_db_client
+from datetime import datetime
+from config.settings import Settings
+from api.auth import get_current_user
+from typing import Dict, List
+
+router = APIRouter()
+
+class Category(BaseModel):
+    code: int
+    label: str
+
+class CategoriesResponse(BaseModel):
+    categories: List[Category]
+
+@router.get("/api/internal/postgresql/entity/categories", response_model=CategoriesResponse)
+async def get_category(current_user: Dict = Depends(get_current_user), request: Request = None):
+    settings: Settings = request.app.state.settings
+    
+    #TODO SETUP ROLE
+    # if "superadmin" not in current_user.get("roles", []):
+    #     raise HTTPException(status_code=403, detail="Not enough permissions")
+
+    async with get_db_client(settings) as conn:
+        rows = await conn.fetch("SELECT code, label FROM categories ORDER BY code")
+        categories = [Category(**dict(r)).model_dump() for r in rows]
+        if categories:
+            return CategoriesResponse(categories=categories)
+
+        raise HTTPException(status_code=404, detail="Categories not found")
+    

--- a/src/api-postgresql/main.py
+++ b/src/api-postgresql/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api import hello as hello_router, auth as auth_router
-from api.postgresql.entity import user, role, ad, category, image
+from api.postgresql.entity import user, role, ad, category, image, categories
 from api.postgresql.relation import roles_users, ads_cats, ads_images, users_ads, ads_users
 from middleware.auth import create_auth_middleware
 from middleware.logging import create_logging_middleware
@@ -34,6 +34,7 @@ def create_app(settings: Settings):
     app.include_router(roles_users.router)
     app.include_router(ad.router)
     app.include_router(category.router)
+    app.include_router(categories.router)
     app.include_router(image.router)
     app.include_router(ads_cats.router)
     app.include_router(ads_images.router)

--- a/src/api-postgresql/test/api/internal/postgresql/entity/test_categories.py
+++ b/src/api-postgresql/test/api/internal/postgresql/entity/test_categories.py
@@ -62,4 +62,8 @@ async def test_gest_categories():
     assert "categories" in categories_data
     categories = categories_data["categories"]
     assert len(categories) >= 2
+    
+    async with get_db_client(test_settings) as db:
+        # Cleanup
+        await db.execute("DELETE FROM users WHERE id = $1", user_id)
 

--- a/src/api-postgresql/test/api/internal/postgresql/entity/test_categories.py
+++ b/src/api-postgresql/test/api/internal/postgresql/entity/test_categories.py
@@ -1,0 +1,65 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import create_app
+from config.db import get_db_client
+from api.auth import create_internal_api_access_token
+from test.config.test_settings import test_settings
+
+def print_response_details(response):
+    """Helper function to print response details if status is not 200."""
+    if response.status_code != 200:
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Body: {response.text}")
+
+@pytest.mark.asyncio
+async def test_gest_categories():
+    app = create_app(test_settings)
+    client = TestClient(app)
+
+    # Step 1: Create a new category
+    api_token = create_internal_api_access_token(data={"scope": "internal"}, settings=test_settings)
+    headers = {
+        "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
+        "X-API-Key": api_token,
+    }
+    response = client.post(
+        "/api/internal/postgresql/entity/user",
+        json={
+            "username": "testuser",
+            "email": "testuser@example.com",
+            "password": "testpassword",
+        },
+        headers=headers,
+    )
+    print_response_details(response)
+    assert response.status_code == 200
+    data = response.json()
+    user_id = data["user_id"]  # Get the user_id from the response
+
+    # Step 2: Get the access token for the created user
+    login_response = client.post(
+        "/token", data={"username": "testuser", "password": "testpassword"}
+    )
+    print_response_details(login_response)
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+
+    # Prepare headers with the access token
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
+        "X-API-Key": api_token,
+    }
+
+    # Test get categories
+    response = client.get(
+        f"/api/internal/postgresql/entity/categories",
+        headers=headers
+    )
+    print_response_details(response)
+    assert response.status_code == 200
+    categories_data = response.json()
+    assert "categories" in categories_data
+    categories = categories_data["categories"]
+    assert len(categories) >= 2
+

--- a/src/api-postgresql/test/api/internal/postgresql/entity/test_role.py
+++ b/src/api-postgresql/test/api/internal/postgresql/entity/test_role.py
@@ -12,196 +12,91 @@ def print_response_details(response):
         print(f"Response Body: {response.text}")
 
 @pytest.mark.asyncio
-async def test_create_role():
+async def test_role_flow():
     app = create_app(test_settings)
     client = TestClient(app)
 
-    # Setup: create a user and get token
+    # Step 1: Create a new category
     api_token = create_internal_api_access_token(data={"scope": "internal"}, settings=test_settings)
     headers = {
         "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
         "X-API-Key": api_token,
     }
+    response = client.post(
+        "/api/internal/postgresql/entity/user",
+        json={
+            "username": "testuser",
+            "email": "testuser@example.com",
+            "password": "testpassword",
+        },
+        headers=headers,
+    )
+    print_response_details(response)
+    assert response.status_code == 200
+    data = response.json()
+    user_id = data["user_id"]  # Get the user_id from the response
 
-    hashed_password = hash_password("password")
-    async with get_db_client(test_settings) as db:
-        # Insert a test user with created_by set to a dummy value
-        user_id = await db.fetchval(
-            "INSERT INTO users (username, email, password, created_by) VALUES ($1, $2, $3, $4) RETURNING id",
-            "testuser", "testuser@example.com", hashed_password, 0  # Assuming 0 as a dummy value for created_by
-        )
+    # Step 2: Get the access token for the created user
+    login_response = client.post(
+        "/token", data={"username": "testuser", "password": "testpassword"}
+    )
+    print_response_details(login_response)
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
 
-        # Get token for the user
-        login_response = client.post(
-            "/token", data={"username": "testuser", "password": "password"}
-        )
-        print_response_details(login_response)
-        assert login_response.status_code == 200
-        token = login_response.json()["access_token"]
-        headers["Authorization"] = f"Bearer {token}"
-
-        # Test create role
-        role_payload = {"name": "testrole"}
-        create_response = client.post(
-            "/api/internal/postgresql/entity/role",
-            json=role_payload,
-            headers=headers
-        )
-        print_response_details(create_response)
-        assert create_response.status_code == 200
-        role_data = create_response.json()
-        assert role_data["name"] == "testrole"
-        role_id = role_data["role_id"]
-
-        # Cleanup
-        await db.execute("DELETE FROM roles WHERE id = $1", role_id)
-        await db.execute("DELETE FROM users WHERE id = $1", user_id)
-
-@pytest.mark.asyncio
-async def test_get_role():
-    app = create_app(test_settings)
-    client = TestClient(app)
-
-    # Setup: create a user and get token
-    api_token = create_internal_api_access_token(data={"scope": "internal"}, settings=test_settings)
+    # Prepare headers with the access token
     headers = {
+        "Authorization": f"Bearer {token}",
         "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
         "X-API-Key": api_token,
     }
 
-    hashed_password = hash_password("password")
+    # Test create role
+    role_payload = {"name": "testrole"}
+    create_response = client.post(
+        "/api/internal/postgresql/entity/role",
+        json=role_payload,
+        headers=headers
+    )
+    print_response_details(create_response)
+    assert create_response.status_code == 200
+    role_data = create_response.json()
+    assert role_data["name"] == "testrole"
+    role_id = role_data["role_id"]
+
+    # Test get role
+    response = client.get(
+        f"/api/internal/postgresql/entity/role/{role_id}",
+        headers=headers
+    )
+    print_response_details(response)
+    assert response.status_code == 200
+    role_data = response.json()
+    assert role_data["name"] == "testrole"
+    assert role_data["role_id"] == role_id
+
+    # Test update role
+    update_payload = {"name": "updated_testrole"}
+    update_response = client.put(
+        f"/api/internal/postgresql/entity/role/{role_id}",
+        json=update_payload,
+        headers=headers
+    )
+    print_response_details(update_response)
+    assert update_response.status_code == 200
+    role_data = update_response.json()
+    assert role_data["name"] == "updated_testrole"
+
+    # Test delete role
+    delete_response = client.delete(
+        f"/api/internal/postgresql/entity/role/{role_id}",
+        headers=headers
+    )
+    print_response_details(delete_response)
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"message": "Role deleted successfully"}
+
     async with get_db_client(test_settings) as db:
-        # Insert a test user with created_by set to a dummy value
-        user_id = await db.fetchval(
-            "INSERT INTO users (username, email, password, created_by) VALUES ($1, $2, $3, $4) RETURNING id",
-            "testuser", "testuser@example.com", hashed_password, 0  # Assuming 0 as a dummy value for created_by
-        )
-
-        # Get token for the user
-        login_response = client.post(
-            "/token", data={"username": "testuser", "password": "password"}
-        )
-        print_response_details(login_response)
-        assert login_response.status_code == 200
-        token = login_response.json()["access_token"]
-        headers["Authorization"] = f"Bearer {token}"
-
-        # Pre-insert a role for the GET test
-        role_id = await db.fetchval(
-            "INSERT INTO roles (name, created_by) VALUES ($1, $2) RETURNING id",
-            "testrole", user_id
-        )
-
-        # Test get role
-        response = client.get(
-            f"/api/internal/postgresql/entity/role/{role_id}",
-            headers=headers
-        )
-        print_response_details(response)
-        assert response.status_code == 200
-        role_data = response.json()
-        assert role_data["name"] == "testrole"
-        assert role_data["role_id"] == role_id
-
-        # Cleanup
-        await db.execute("DELETE FROM roles WHERE id = $1", role_id)
-        await db.execute("DELETE FROM users WHERE id = $1", user_id)
-
-@pytest.mark.asyncio
-async def test_update_role():
-    app = create_app(test_settings)
-    client = TestClient(app)
-
-    # Setup: create a user and get token
-    api_token = create_internal_api_access_token(data={"scope": "internal"}, settings=test_settings)
-    headers = {
-        "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
-        "X-API-Key": api_token,
-    }
-
-    hashed_password = hash_password("password")
-    async with get_db_client(test_settings) as db:
-        # Insert a test user with created_by set to a dummy value
-        user_id = await db.fetchval(
-            "INSERT INTO users (username, email, password, created_by) VALUES ($1, $2, $3, $4) RETURNING id",
-            "testuser", "testuser@example.com", hashed_password, 0  # Assuming 0 as a dummy value for created_by
-        )
-
-        # Get token for the user
-        login_response = client.post(
-            "/token", data={"username": "testuser", "password": "password"}
-        )
-        print_response_details(login_response)
-        assert login_response.status_code == 200
-        token = login_response.json()["access_token"]
-        headers["Authorization"] = f"Bearer {token}"
-
-        # Pre-insert a role for the UPDATE test
-        role_id = await db.fetchval(
-            "INSERT INTO roles (name, created_by) VALUES ($1, $2) RETURNING id",
-            "testrole", user_id
-        )
-
-        # Test update role
-        update_payload = {"name": "updated_testrole"}
-        update_response = client.put(
-            f"/api/internal/postgresql/entity/role/{role_id}",
-            json=update_payload,
-            headers=headers
-        )
-        print_response_details(update_response)
-        assert update_response.status_code == 200
-        role_data = update_response.json()
-        assert role_data["name"] == "updated_testrole"
-
-        # Cleanup
-        await db.execute("DELETE FROM roles WHERE id = $1", role_id)
-        await db.execute("DELETE FROM users WHERE id = $1", user_id)
-
-@pytest.mark.asyncio
-async def test_delete_role():
-    app = create_app(test_settings)
-    client = TestClient(app)
-
-    # Setup: create a user and get token
-    api_token = create_internal_api_access_token(data={"scope": "internal"}, settings=test_settings)
-    headers = {
-        "Referer": test_settings.API_GATEWAY_HOST + test_settings.PROTECTED_ENDPOINT_URL,
-        "X-API-Key": api_token,
-    }
-
-    hashed_password = hash_password("password")
-    async with get_db_client(test_settings) as db:
-        # Insert a test user with created_by set to a dummy value
-        user_id = await db.fetchval(
-            "INSERT INTO users (username, email, password, created_by) VALUES ($1, $2, $3, $4) RETURNING id",
-            "testuser", "testuser@example.com", hashed_password, 0  # Assuming 0 as a dummy value for created_by
-        )
-
-        # Get token for the user
-        login_response = client.post(
-            "/token", data={"username": "testuser", "password": "password"}
-        )
-        print_response_details(login_response)
-        assert login_response.status_code == 200
-        token = login_response.json()["access_token"]
-        headers["Authorization"] = f"Bearer {token}"
-
-        # Pre-insert a role for the DELETE test
-        role_id = await db.fetchval(
-            "INSERT INTO roles (name, created_by) VALUES ($1, $2) RETURNING id",
-            "testrole", user_id
-        )
-
-        # Test delete role
-        delete_response = client.delete(
-            f"/api/internal/postgresql/entity/role/{role_id}",
-            headers=headers
-        )
-        print_response_details(delete_response)
-        assert delete_response.status_code == 200
-        assert delete_response.json() == {"message": "Role deleted successfully"}
-
         # Verify role deletion
         deleted_role_in_db = await db.fetchrow("SELECT * FROM roles WHERE id = $1", role_id)
         assert deleted_role_in_db is None, "Role was not deleted from the database"


### PR DESCRIPTION
Ajout d'un endpoint qui renvoi toutes les catégories de PostgreSQL pour le Front afin de pouvoir proposer les catégories existantes lors d'une création d'annonce.

==> dispo sur `/get_categories`