### PR TITLE
Fix category issue on create_ad

### DIFF
--- a/src/api-gateway/api/auth/clients/postgresql.py
+++ b/src/api-gateway/api/auth/clients/postgresql.py
@@ -210,3 +210,18 @@ class PostgreSQLClient:
 
         return response.json()
 
+    def get_category_id(self, token: str, table: str, code: int) -> Dict[str, Any]:
+        """ Récupère l'id d'une catégorie. """
+        base_url = self.settings.API_POSTGRESQL_BASE_URL
+        headers = self.get_headers(token)
+        session = self.get_session()
+
+        endpoint = f"{base_url}/api/internal/postgresql/entity/category/{table}/{code}"
+        logger.debug(f"Request URL: {endpoint}")
+
+        response = session.get(endpoint, headers=headers)
+        logger.debug(f"Response Status Code: {response.status_code}")
+        logger.debug(f"Response Content: {response.text}")
+        response.raise_for_status()
+
+        return response.json()

--- a/src/api-gateway/api/routes/ad/create.py
+++ b/src/api-gateway/api/routes/ad/create.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict, cast
 from config.settings import Settings
 from api.auth.clients.manager import ClientManager, create_client_manager
 from api.auth.token.manager import TokenManager, create_token_manager
+from pathlib import Path
 
 DEFAULT_BUCKET = "raw-images"
 
@@ -43,6 +44,11 @@ def get_user_data_from_token(
     logger.info("Extracting user data from token...")
     return token_manager.get_user_data_from_token(authorization)
 
+def get_id_category(code, table, client, token):
+    response = client.get_category_id(token=token, table=table, code=code)
+    logger.debug(f"PostgreSQL get id_category '{table}' response: {response}")
+    return response
+
 def insert_psql_table(data, table, client, token, relation=False):
     """ Insert data in PostgreSQL """
     try:
@@ -69,8 +75,8 @@ def insert_entities(ad_data, cat_data, image_data,
     ad_response = insert_psql_table(ad_data, "ad", 
                                     postgresql_client, postgresql_token)
     ad_id = ad_response["id"]
-    # Insert in 'categories' on PostgreSQL
-    cat_response = insert_psql_table(cat_data, "category", 
+    # Get 'category' ID on PostgreSQL
+    cat_response = get_id_category(int(cat_data["code"]), "by-code", 
                                      postgresql_client, postgresql_token)
     cat_id = cat_response["id"]
     # Insert in 'image' on PostgreSQL

--- a/src/api-gateway/test/entity/test_flow_ad.py
+++ b/src/api-gateway/test/entity/test_flow_ad.py
@@ -51,8 +51,8 @@ def _create_ad(headers):
         data = {
             "designation": "Produit flow",
             "description": "Desc flow init",
-            "category_code": 1000,
-            "category_label": "CAT1",
+            "category_code": 10,
+            "category_label": "Livre occasion",
         }
         response = client.post(
             f"{test_settings.PROTECTED_ENDPOINT_URL}/create_ad",

--- a/src/api-minio/api/minio/entity/images.py
+++ b/src/api-minio/api/minio/entity/images.py
@@ -143,20 +143,20 @@ def _store_temp_image_from_bytes(
 ) -> tuple[str, ImageInfo]:
     if image_id is None:
         image_id = uuid.uuid4()
-    # TODO: Accept other format on top of JPG
-    image_path = os.path.join(bucket, f"{image_id}.jpg")
+    
+    image_path = os.path.join(bucket, str(image_id))
     image_name = filename or f"{image_id}"
 
     stream = io.BytesIO(file)
     image = Image.open(stream)
-    image_id = str(uuid.uuid4())
+    #image_id = str(uuid.uuid4())
     info = ImageInfo(
-        image_id=image_id,
+        image_id=str(image_id),
         image_name=image_name,
         bucket_path=image_path,
         created_at=datetime.now().strftime(format=DATETIME_FORMAT),
     )
-
+    # TODO: Accept other format on top of JPG
     tmp_path = os.path.join(tmp_folder, f"{image_id}.jpg")
     image.save(tmp_path)
 

--- a/src/api-postgresql/api/postgresql/entity/category.py
+++ b/src/api-postgresql/api/postgresql/entity/category.py
@@ -39,7 +39,7 @@ async def create_category(request: Request, data: Category, current_user: dict =
             data_dict["created_at"],
             data_dict["created_by"]
         )
-        data_dict["id"] = str(category_id)
+        data_dict["id"] = category_id
         return CategoryResponse(**data_dict)
 
 @router.get("/api/internal/postgresql/entity/category/{category_id}", response_model=CategoryResponse)
@@ -105,5 +105,24 @@ async def delete_category(category_id: int, current_user: Dict = Depends(get_cur
             return {"message": "Category deleted successfully"}
         raise HTTPException(status_code=404, detail="Category not found")
 
+@router.get("/api/internal/postgresql/entity/category/by-code/{code}", response_model=CategoryResponse)
+async def get_category_by_code(code: int, current_user: Dict = Depends(get_current_user), request: Request = None):
+    settings: Settings = request.app.state.settings
 
+    #TODO SETUP ROLE
+    # if "superadmin" not in current_user.get("roles", []):
+    #     raise HTTPException(status_code=403, detail="Not enough permissions")
+
+    async with get_db_client(settings) as conn:
+        result = await conn.fetchrow(
+            """
+            SELECT id, code, label, created_at, created_by
+            FROM categories
+            WHERE code = $1
+            """,
+            code
+        )
+        if result:
+            return CategoryResponse(**result)
+        raise HTTPException(status_code=404, detail="Category not found")
 

--- a/src/postgresql/postgresql/init-postgresql.sql
+++ b/src/postgresql/postgresql/init-postgresql.sql
@@ -55,8 +55,8 @@ CREATE TABLE categories (
 -- Créer une table images
 CREATE TABLE images (
     id SERIAL PRIMARY KEY,
-    image_name VARCHAR(50),
-    image_uuid VARCHAR(50) UNIQUE,
+    image_name VARCHAR(100),
+    image_uuid VARCHAR(100) UNIQUE,
     bucket_path VARCHAR(100),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by INT NOT NULL


### PR DESCRIPTION
1er fix: 
Modifie le comportement de "create_ad", ne vient plus écrire la catégorie en base (qui générait une erreur car on ne peut pas avoir de doublon) mais vient récupérer l'id pour ensuite faire les relations.

2ème fix:
Supprime l'extension de l'image dans la variable "bucket_path" 